### PR TITLE
Deploy site to AWS Amplify using CloudFormation

### DIFF
--- a/bin/deploy
+++ b/bin/deploy
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+
+aws cloudformation deploy \
+    --template-file ./deploy/template.yaml \
+    --capabilities CAPABILITY_IAM \
+    --parameter-overrides \
+    OauthToken=????
+    Repository=https://github.com/dylanpinn/dylanp.dev \
+    --stack-name TodoApp \
+    --role-arn arn:aws:iam::211125554115:role/dylanp-dev-deployment-role-DeploymentRole-x1GLlzQHLMKb \
+    --profile PowerUserAccess-211125554115

--- a/bin/deploy-deployment-role
+++ b/bin/deploy-deployment-role
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+
+aws cloudformation deploy \
+    --template-file ./deploy/deploy-role-template.yaml \
+    --capabilities CAPABILITY_IAM \
+    --stack-name dylanp-dev-deployment-role \
+    --profile AdministratorAccess-211125554115

--- a/deploy/deploy-role-template.yaml
+++ b/deploy/deploy-role-template.yaml
@@ -1,0 +1,25 @@
+AWSTemplateFormatVersion: "2010-09-09"
+Description: Template to deploy an IAM Role to deploy this app.
+Resources:
+  DeploymentRole:
+    Type: "AWS::IAM::Role"
+    Properties: 
+      AssumeRolePolicyDocument:
+        Version: "2012-10-17"
+        Statement:
+          - Effect: Allow
+            Principal:
+              Service:
+                - cloudformation.amazonaws.com
+            Action:
+              - 'sts:AssumeRole'
+      Description: IAM Role that should have only the required access to deploy this application.
+      Policies:
+        - PolicyName: root # TODO: This will need to be paired back. Just want to check that it works.
+          PolicyDocument:
+            Version: "2012-10-17"
+            Statement:
+              - Effect: Allow
+                Action: '*'
+                Resource: '*'
+

--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -1,0 +1,75 @@
+AWSTemplateFormatVersion: 2010-09-09
+
+Parameters:
+  Repository:
+    Type: String
+    Description: GitHub Repository URL
+
+  OauthToken:
+    Type: String
+    Description: GitHub Repository URL
+    NoEcho: true
+
+Resources:
+  AmplifyRole:
+    Type: AWS::IAM::Role
+    Properties:
+      AssumeRolePolicyDocument:
+        Version: 2012-10-17
+        Statement:
+          - Effect: Allow
+            Principal:
+              Service:
+                - amplify.amazonaws.com
+            Action:
+              - sts:AssumeRole
+      Policies:
+        - PolicyName: Amplify
+          PolicyDocument:
+            Version: 2012-10-17
+            Statement:
+              - Effect: Allow
+                Action: "amplify:*"
+                Resource: "*"
+
+  AmplifyApp:
+    Type: "AWS::Amplify::App"
+    Properties:
+      Name: TodoApp
+      Repository: !Ref Repository
+      Description: VueJS Todo example app
+      OauthToken: !Ref OauthToken
+      BuildSpec: |-
+        version: 0.1
+        frontend:
+          phases:
+            build:
+              commands:
+                - mkdir dist
+                - cp index.html dist/index.html
+          artifacts:
+            baseDirectory: dist/
+            files:
+              - '*'
+      Tags:
+        - Key: Name
+          Value: Todo
+      IAMServiceRole: !GetAtt AmplifyRole.Arn
+
+  AmplifyBranch:
+    Type: AWS::Amplify::Branch
+    Properties:
+      BranchName: main
+      AppId: !GetAtt AmplifyApp.AppId
+      Description: Main Branch
+      EnableAutoBuild: true
+      Tags:
+        - Key: Name
+          Value: todo-main
+        - Key: Branch
+          Value: main
+
+Outputs:
+  DefaultDomain:
+    Value: !GetAtt AmplifyApp.DefaultDomain
+


### PR DESCRIPTION
Rough task list

- [ ] Replace main template from example TODO to be more specific
- [ ] Tear down stack and redeploy with new name
- [ ] Tear down again and remove all permissions from deploy role
- [ ] Start trying to deploy while adding permissions as required
- [ ] Investigate GitHub sync for templates, can we remove the deploy scripts?
- [ ] Validate templates using `aws cloudformation validate`
- [ ] DNS
